### PR TITLE
Fixes arg name inconsistency

### DIFF
--- a/src/hrtime.coffee
+++ b/src/hrtime.coffee
@@ -9,7 +9,7 @@ hrtime = (prevTime) ->
   seconds = Math.floor clockTime
   ns = Math.floor((clockTime % 1) * 1e9)
 
-  if prevTimestamp
+  if prevTime
     seconds = seconds - prevTime[0]
     ns = ns - prevTime[1]
     if ns < 0


### PR DESCRIPTION
`stopwatch` was failing for me with `ReferenceError: prevTimestamp is not defined`. This appears to be due the arg name in `hrtime` being `prevTime`, not `prevTimestamp`.